### PR TITLE
don't send error when job have reschedule attempts

### DIFF
--- a/lib/delayed-plugins-airbrake.rb
+++ b/lib/delayed-plugins-airbrake.rb
@@ -8,15 +8,17 @@ module Delayed::Plugins::Airbrake
   class Plugin < ::Delayed::Plugin
     module Notify
       def error(job, exception)
-        ::Airbrake.notify(exception,
-          :error_class   => exception.class.name,
-          :error_message => "#{exception.class.name}: #{exception.message}",
-          :backtrace     => exception.backtrace,
-          :component     => 'DelayedJob Worker',
-          :parameters    => {
-            :failed_job => job.inspect
-          }
-        )
+        if (job.attempts + 1) >= (job.max_attempts || Delayed::Worker.max_attempts)
+          ::Airbrake.notify(exception,
+            :error_class   => exception.class.name,
+            :error_message => "#{exception.class.name}: #{exception.message}",
+            :backtrace     => exception.backtrace,
+            :component     => 'DelayedJob Worker',
+            :parameters    => {
+              :failed_job => job.inspect
+            }
+          )
+        end
         super if defined?(super)
       end
     end

--- a/lib/delayed-plugins-airbrake.rb
+++ b/lib/delayed-plugins-airbrake.rb
@@ -8,6 +8,8 @@ module Delayed::Plugins::Airbrake
   class Plugin < ::Delayed::Plugin
     module Notify
       def error(job, exception)
+        return if defined?(super) # don't airbrake if custom handler defined 
+        
         if (job.attempts + 1) >= (job.max_attempts || Delayed::Worker.max_attempts)
           ::Airbrake.notify(exception,
             :error_class   => exception.class.name,


### PR DESCRIPTION
don't send error when job have reschedule attempts, only when job fail last time

At least I need that, I know that some jobs can fail, but they rescheduled, I need notification only when job "REMOVED permanently because of 3 consecutive failures"
